### PR TITLE
Fix hash and models

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :questions, inverse_of: :user, dependent: :destroy
+  has_many :questions, dependent: :destroy
   has_many :genres, through: :genre_users, inverse_of: :user
   has_many :genre_users, dependent: :destroy
 

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,4 +1,4 @@
 <h1>Questions#index</h1>
 <p>Find me in app/views/questions/index.html.erb</p>
-  <%= render partial: 'shared/question_form', locals: {question: @question} %>
-  <%= render partial: 'shared/feed', locals: {feed_items: @feed_items} %>
+  <%= render partial: 'shared/question_form', locals: { question: @question } %>
+  <%= render partial: 'shared/feed', locals: { feed_items: @feed_items } %>


### PR DESCRIPTION
# WHAT
Userモデルのinverse_ofオプションを削除（rails4.1以降はデフォルトで設定されている）
ハッシュにスペース追加

# WHY
無駄がなく読みやすい綺麗なコードを書く。