### PR TITLE
Add gem acts as taggable on

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "sass-rails", "~> 5.0"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
 gem "acts_as_follower", github: "tcocca/acts_as_follower", branch: "master"
+gem 'acts-as-taggable-on', '~> 4.0'
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
@@ -225,6 +227,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 4.0)
   acts_as_follower!
   byebug
   capybara (~> 2.13)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,9 @@ class UsersController < ApplicationController
       :profile_image,
       :cover_image,
       :area,
-      :introduce
+      :introduce,
+      :skill_list,
+      :interest_list,
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   acts_as_followable
   acts_as_follower
 
+  acts_as_taggable_on :skills, :interests
+
   def feed
     following_ids = "SELECT followable_id FROM follows WHERE follower_id = :user_id"
     Question.where("user_id IN (#{following_ids}) OR user_id = :user_id", user_id: id)

--- a/app/views/users/_tag_list.html.erb
+++ b/app/views/users/_tag_list.html.erb
@@ -1,0 +1,3 @@
+<% tag_list.each do |tag| %>
+  <%= tag %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -28,6 +28,13 @@
 
   <%= f.label :introduce %>
   <%= f.text_area :introduce %>
+
+  <%= f.label :skill_list, "Skills" %>
+  <%= text_field_tag 'user[skill_list]', @user.skill_list.join(',') %>
+
+  <%= f.label :interest_list, "Interests" %>
+  <%= text_field_tag 'user[interest_list]', @user.interest_list.join(',') %>
+
   <!-- リスト形式ここまで -->
 
   <%= f.submit "Update profile" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,15 +5,14 @@
 <p><%= @user.alias_name %></p>
 <p><%= @user.area %></p>
 <p><%= @user.introduce %></p>
-<div>
-  <% if @user.genre_users.any? %>
-    <p><%= @user.name %>'s Genres</p>
-      <ol class="genre_users" >
-        <!-- FIXME 後のブランチにてユーザーが登録したジャンルが表示されるようにする -->
-      </ol>
-  <% end %>
-</div>
-<!-- ユーザーが投稿した質問もタイムライン形式で表示させる -->
+
+<p><%= render 'users/tag_list', tag_list: @user.skill_list %></p>
+<p><%= render 'users/tag_list', tag_list: @user.interest_list %></p>
+
+<% if current_user == @user %>
+  <p><%= link_to "Update profile", edit_user_path(current_user) %></p>
+<% end %>
+
 <%= render 'shared/stats' %>
 <% if signed_in? %>
 <%= render 'users/follow_form' unless current_user.id == @user.id %>

--- a/db/migrate/20180204232324_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232324_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+      t.string :context, limit: 128
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20180204232325_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232325_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20180204232326_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232326_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20180204232327_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232327_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,9 @@
+class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20180204232328_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232328_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,7 @@
+class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20180204232329_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180204232329_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,12 @@
+class AddMissingIndexes < ActiveRecord::Migration[4.2]
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106083306) do
+ActiveRecord::Schema.define(version: 20180204232329) do
 
   create_table "answers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "content", null: false
@@ -62,6 +62,31 @@ ActiveRecord::Schema.define(version: 20180106083306) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
+  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", collation: "utf8_bin"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# WHAT
gem acts-as-taggable-onをインストールし、タグ機能を実装

#WHY
初期の構想ではgenresテーブルに予め選択肢を保存し、ユーザーに選んでもらう仕様にする予定でした。
しかしユーザー目線に立つと、ユーザー自身が自由にタグ付け出来たほうが良いと考え、acts-as-taggable-onを使用することにしました。